### PR TITLE
Update Guava to eliminate a security vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,9 @@
     <properties>
         <!-- Dependency Versions, keep in alphabetical order -->
         <version.jakarta.ee>10.0.0</version.jakarta.ee>
+        <!-- Override transitive dependency coming in via Guice. The Guava version brought in by Guice has a security vulnerability -->
+        <!-- Check to see if it can be removed when updating Guice. -->
+        <version.com.google.guava.guava>33.3.1-jre</version.com.google.guava.guava>
         <version.com.google.inject.guice>7.0.0</version.com.google.inject.guice>
         <version.org.jboss.logging>3.6.1.Final</version.org.jboss.logging>
         <version.org.jboss.logging.jboss-logging-tools>3.0.1.Final</version.org.jboss.logging.jboss-logging-tools>
@@ -62,6 +65,11 @@
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
             <version>${version.com.google.inject.guice}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${version.com.google.guava.guava}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.inject</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,16 +20,6 @@
     <name>RESTEasy Guice</name>
     <description/>
 
-    <properties>
-        <!-- Dependency Versions, keep in alphabetical order -->
-        <version.jakarta.ee>10.0.0</version.jakarta.ee>
-        <version.com.google.inject.guice>7.0.0</version.com.google.inject.guice>
-        <version.org.jboss.logging>3.6.1.Final</version.org.jboss.logging>
-        <version.org.jboss.logging.jboss-logging-tools>3.0.1.Final</version.org.jboss.logging.jboss-logging-tools>
-        <version.org.jboss.resteasy>6.2.10.Final</version.org.jboss.resteasy>
-        <version.org.junit>5.11.1</version.org.junit>
-    </properties>
-
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -56,12 +46,29 @@
         </dependencies>
     </dependencyManagement>
 
-    <dependencies>
+    <properties>
+        <!-- Dependency Versions, keep in alphabetical order -->
+        <version.jakarta.ee>10.0.0</version.jakarta.ee>
+        <!-- Override transitive dependency coming in via Guice. The Guava version brought in by Guice has a security vulnerability -->
+        <!-- Check to see if it can be removed when updating Guice. -->
+        <version.com.google.guava.guava>33.3.1-jre</version.com.google.guava.guava>
+        <version.com.google.inject.guice>7.0.0</version.com.google.inject.guice>
+        <version.org.jboss.logging>3.6.1.Final</version.org.jboss.logging>
+        <version.org.jboss.logging.jboss-logging-tools>3.0.1.Final</version.org.jboss.logging.jboss-logging-tools>
+        <version.org.jboss.resteasy>6.2.10.Final</version.org.jboss.resteasy>
+        <version.org.junit>5.11.1</version.org.junit>
+    </properties>
 
+    <dependencies>
         <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
             <version>${version.com.google.inject.guice}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${version.com.google.guava.guava}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.inject</groupId>


### PR DESCRIPTION
This is addresses the following security vulnerability:

https://devhub.checkmarx.com/cve-details/CVE-2023-2976/